### PR TITLE
ReceiveMessageAsync should await the call to the handler

### DIFF
--- a/ServiceFabric.ServiceBus.Services/CommunicationListeners/ServiceBusCommunicationListener.cs
+++ b/ServiceFabric.ServiceBus.Services/CommunicationListeners/ServiceBusCommunicationListener.cs
@@ -174,12 +174,12 @@ namespace ServiceFabric.ServiceBus.Services.CommunicationListeners
         /// Will pass an incoming message to the <see cref="Receiver"/> for processing.
         /// </summary>
         /// <param name="message"></param>
-        protected Task ReceiveMessageAsync(BrokeredMessage message)
+        protected async Task ReceiveMessageAsync(BrokeredMessage message)
         {
             try
             {
                 _processingMessage.Reset();
-                return Receiver.ReceiveMessageAsync(message, StopProcessingMessageToken);
+                await Receiver.ReceiveMessageAsync(message, StopProcessingMessageToken);
             }
             finally
             {


### PR DESCRIPTION
ServiceBusCommunicationListener.ReceiveMessageAsync disposes the message to early when the handler performs an async operation itself. After an await in the handler the message is already disposed and cannot be completed.
